### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/applet.php
+++ b/syntax/applet.php
@@ -90,7 +90,7 @@ class syntax_plugin_netlogo_applet extends DokuWiki_Syntax_Plugin {
 //        $this->Lexer->addExitPattern('</FIXME>','plugin_netlogo_applet');
 //    }
 
-    public function handle($match, $state, $pos, &$handler){
+    public function handle($match, $state, $pos, Doku_Handler $handler){
 		/*
 		 * Copied from DokuWiki media handler in
 		 * http://xref.dokuwiki.org/reference/dokuwiki/_functions/doku_handler_parse_media.html
@@ -177,7 +177,7 @@ class syntax_plugin_netlogo_applet extends DokuWiki_Syntax_Plugin {
 		return $params;
     }
 
-    public function render($mode, &$renderer, $data) {
+    public function render($mode, Doku_Renderer $renderer, $data) {
 		global $ID, $conf;
 		
         if($mode != 'xhtml') return false;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
